### PR TITLE
Fix argument order

### DIFF
--- a/softaware.Holidays.Core.Tests/Tests.cs
+++ b/softaware.Holidays.Core.Tests/Tests.cs
@@ -9,16 +9,16 @@ namespace softaware.Holidays.Core.Tests
         public void EasterSunday2018()
         {
             Assert.Equal(
-                new Generator().EasterSunday(2018),
-                new DateTime(2018, 4, 1));
+                new DateTime(2018, 4, 1),
+                new Generator().EasterSunday(2018));
         }
         
         [Fact]
         public void EasterSunday2019()
         {
             Assert.Equal(
-                new Generator().EasterSunday(2019),
-                new DateTime(2019, 4, 21));
+                new DateTime(2019, 4, 21),
+                new Generator().EasterSunday(2019));
         }
     }
 }


### PR DESCRIPTION
It's `Assert.Equal(expected, actual)`, but it was used the other way around.